### PR TITLE
Explicitly add JSON Gem

### DIFF
--- a/lib/quip/client.rb
+++ b/lib/quip/client.rb
@@ -1,4 +1,5 @@
 require 'rest-client'
+require 'json'
 
 module Quip
   class QuipClient

--- a/lib/quip/version.rb
+++ b/lib/quip/version.rb
@@ -1,3 +1,3 @@
 module Quip
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/quip.gemspec
+++ b/quip.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rest-client'
+  spec.add_dependency 'json'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'pry'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ require 'webmock/rspec'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
## Added
* JSON gem added to `client.rb` and `gemspec`

## Removed
* Removed deprecated Rspec `treat_symbols_as_metadata_keys_with_true_values()` option